### PR TITLE
Patch jsonschema-tools to avoid sorting keys

### DIFF
--- a/patches/@wikimedia+jsonschema-tools+1.3.0.patch
+++ b/patches/@wikimedia+jsonschema-tools+1.3.0.patch
@@ -1,14 +1,14 @@
 diff --git a/node_modules/@wikimedia/jsonschema-tools/lib/jsonschema-tools.js b/node_modules/@wikimedia/jsonschema-tools/lib/jsonschema-tools.js
-index acd2991..1e1591c 100644
+index acd2991..cc239f3 100644
 --- a/node_modules/@wikimedia/jsonschema-tools/lib/jsonschema-tools.js
 +++ b/node_modules/@wikimedia/jsonschema-tools/lib/jsonschema-tools.js
-@@ -212,7 +212,7 @@ function jsonStableStringifySchemaCompare(kv1, kv2) {
-  */
- const serializers = {
-     yaml: (obj) => { return yaml.dump(obj, { sortKeys: schemaKeyCompare }); },
--    json: (obj) => { return jsonStableStringify(obj, { cmp: jsonStableStringifySchemaCompare, space: 2 }); },
-+    json: (obj) => { return jsonStableStringify(obj, { cmp: () => 1, space: 2 }); }, // Do not sort JSON keys
- };
+@@ -192,7 +192,7 @@ function schemaKeyCompare(k1, k2) {
+     } else if (k2 in schemaKeySortOrder) {
+         return 1;
+     }
+-    return k1.localeCompare(k2);
++    return 1; // Do not sort any other keys
+ }
  
  /**
 diff --git a/node_modules/@wikimedia/jsonschema-tools/lib/tests/structure.js b/node_modules/@wikimedia/jsonschema-tools/lib/tests/structure.js

--- a/patches/@wikimedia+jsonschema-tools+1.3.0.patch
+++ b/patches/@wikimedia+jsonschema-tools+1.3.0.patch
@@ -1,3 +1,16 @@
+diff --git a/node_modules/@wikimedia/jsonschema-tools/lib/jsonschema-tools.js b/node_modules/@wikimedia/jsonschema-tools/lib/jsonschema-tools.js
+index acd2991..15da16e 100644
+--- a/node_modules/@wikimedia/jsonschema-tools/lib/jsonschema-tools.js
++++ b/node_modules/@wikimedia/jsonschema-tools/lib/jsonschema-tools.js
+@@ -212,7 +212,7 @@ function jsonStableStringifySchemaCompare(kv1, kv2) {
+  */
+ const serializers = {
+     yaml: (obj) => { return yaml.dump(obj, { sortKeys: schemaKeyCompare }); },
+-    json: (obj) => { return jsonStableStringify(obj, { cmp: jsonStableStringifySchemaCompare, space: 2 }); },
++    json: (obj) => { return jsonStableStringify(obj, { cmp: () => 1, space: 2 }); },
+ };
+ 
+ /**
 diff --git a/node_modules/@wikimedia/jsonschema-tools/lib/tests/structure.js b/node_modules/@wikimedia/jsonschema-tools/lib/tests/structure.js
 index b09a2c1..ea0d2c8 100644
 --- a/node_modules/@wikimedia/jsonschema-tools/lib/tests/structure.js

--- a/patches/@wikimedia+jsonschema-tools+1.3.0.patch
+++ b/patches/@wikimedia+jsonschema-tools+1.3.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@wikimedia/jsonschema-tools/lib/jsonschema-tools.js b/node_modules/@wikimedia/jsonschema-tools/lib/jsonschema-tools.js
-index acd2991..15da16e 100644
+index acd2991..1e1591c 100644
 --- a/node_modules/@wikimedia/jsonschema-tools/lib/jsonschema-tools.js
 +++ b/node_modules/@wikimedia/jsonschema-tools/lib/jsonschema-tools.js
 @@ -212,7 +212,7 @@ function jsonStableStringifySchemaCompare(kv1, kv2) {
@@ -7,7 +7,7 @@ index acd2991..15da16e 100644
  const serializers = {
      yaml: (obj) => { return yaml.dump(obj, { sortKeys: schemaKeyCompare }); },
 -    json: (obj) => { return jsonStableStringify(obj, { cmp: jsonStableStringifySchemaCompare, space: 2 }); },
-+    json: (obj) => { return jsonStableStringify(obj, { cmp: () => 1, space: 2 }); },
++    json: (obj) => { return jsonStableStringify(obj, { cmp: () => 1, space: 2 }); }, // Do not sort JSON keys
  };
  
  /**

--- a/schemas/examples/advanced/1.0.1.json
+++ b/schemas/examples/advanced/1.0.1.json
@@ -39,17 +39,17 @@
           "format": "uuid",
           "maxLength": 40
         },
-        "is_confidential": {
-          "title": "Is Confidential",
-          "description": "True if entry is confidential, adding in basic 1.0.1",
-          "type": "boolean"
-        },
         "when": {
           "title": "When last reviewed",
           "description": "An ISO-8601 formatted timestamp added in basic 1.0.0",
           "type": "string",
           "format": "date-time",
           "maxLength": 128
+        },
+        "is_confidential": {
+          "title": "Is Confidential",
+          "description": "True if entry is confidential, adding in basic 1.0.1",
+          "type": "boolean"
         }
       },
       "examples": [
@@ -60,8 +60,8 @@
           "comment": "Example showing all values in basic 1.0.0 version.",
           "counter": 101,
           "ident": "3e4666bf-d5e5-4aa7-b8ce-cefe41c7568a",
-          "is_confidential": true,
-          "when": "2018-11-13T20:20:39+00:00"
+          "when": "2018-11-13T20:20:39+00:00",
+          "is_confidential": true
         }
       ]
     }
@@ -70,10 +70,10 @@
     {
       "basic_from": {
         "comment": "dolor",
-        "counter": 150,
         "ident": "22222222-2222-2222-2222-222222222222",
+        "when": "2021-01-01T00:00:00.0Z",
         "is_confidential": false,
-        "when": "2021-01-01T00:00:00.0Z"
+        "counter": 150
       }
     }
   ]

--- a/schemas/examples/basic/1.0.1.json
+++ b/schemas/examples/basic/1.0.1.json
@@ -28,17 +28,17 @@
       "format": "uuid",
       "maxLength": 40
     },
-    "is_confidential": {
-      "title": "Is Confidential",
-      "description": "True if entry is confidential, adding in basic 1.0.1",
-      "type": "boolean"
-    },
     "when": {
       "title": "When last reviewed",
       "description": "An ISO-8601 formatted timestamp added in basic 1.0.0",
       "type": "string",
       "format": "date-time",
       "maxLength": 128
+    },
+    "is_confidential": {
+      "title": "Is Confidential",
+      "description": "True if entry is confidential, adding in basic 1.0.1",
+      "type": "boolean"
     }
   },
   "examples": [
@@ -49,8 +49,8 @@
       "comment": "Example showing all values in basic 1.0.0 version.",
       "counter": 101,
       "ident": "3e4666bf-d5e5-4aa7-b8ce-cefe41c7568a",
-      "is_confidential": true,
-      "when": "2018-11-13T20:20:39+00:00"
+      "when": "2018-11-13T20:20:39+00:00",
+      "is_confidential": true
     }
   ]
 }

--- a/schemas/samples/i15-1/powder/0.0.1.json
+++ b/schemas/samples/i15-1/powder/0.0.1.json
@@ -9,6 +9,28 @@
     "packing_fraction"
   ],
   "properties": {
+    "composition": {
+      "title": "Composition",
+      "description": "Molar composition of sample",
+      "type": "string",
+      "default": "C"
+    },
+    "density": {
+      "title": "Density",
+      "description": "Density of sample in g/cm^3",
+      "type": "number",
+      "default": 1,
+      "minimum": 0,
+      "maximum": 1000
+    },
+    "packing_fraction": {
+      "title": "Packing Fraction",
+      "description": "Packing fraction of the sample in the capillary",
+      "type": "number",
+      "default": 0.5,
+      "minimum": 0,
+      "maximum": 1
+    },
     "capillary": {
       "title": "Capillary",
       "description": "The capillary type of this sample.",
@@ -33,37 +55,15 @@
       "description": "Comment on this sample",
       "type": "string",
       "default": ""
-    },
-    "composition": {
-      "title": "Composition",
-      "description": "Molar composition of sample",
-      "type": "string",
-      "default": "C"
-    },
-    "density": {
-      "title": "Density",
-      "description": "Density of sample in g/cm^3",
-      "type": "number",
-      "default": 1,
-      "maximum": 1000,
-      "minimum": 0
-    },
-    "packing_fraction": {
-      "title": "Packing Fraction",
-      "description": "Packing fraction of the sample in the capillary",
-      "type": "number",
-      "default": 0.5,
-      "maximum": 1,
-      "minimum": 0
     }
   },
   "examples": [
     {
-      "capillary": "bs1.5",
-      "comment": "",
       "composition": "C",
       "density": 1,
-      "packing_fraction": 0.5
+      "packing_fraction": 0.5,
+      "comment": "",
+      "capillary": "bs1.5"
     }
   ]
 }


### PR DESCRIPTION
Currently when running commands such as `npm run build-all` keys inside `properties` get sorted into alphabetical order. We would prefer the original order is preserved.

Check when running this no alphabetisation is applied to keys inside `properties`.

After merging we should merge the open branches to bring in these changes.