### PR TITLE
Ulims 511 lesscommonissues

### DIFF
--- a/docs/common_issues.md
+++ b/docs/common_issues.md
@@ -172,3 +172,29 @@ each schema is seperate they will have different
 release numbers. Often quicker to start new branch.
 
 </details>
+
+
+## Issues with examples
+
+Every release of every scheme should have at least 1
+example tied to it and this issue occurs if any
+are now invalid. The build will add an example block
+to every file released which uses the example block from
+current.json or generates that block containing
+required properties. Can also occur when editing
+released json files manually.
+
+Example number and message can vary. Example 0 should
+always be the required properties. Example 1 is recommended
+to contain properties most commonly used by applications.
+
+<details>
+<summary>check: "example 0 did not validate against schema: data should NOT have additional properties"</summary>
+
+### Check typo or remove property from example
+
+**Fix:** Edit current.json and confirm the property in the example
+is defined by the schema. If not, remove from example or correct
+spelling mistake. Rebuild and check will pass again.
+
+</details>

--- a/docs/common_issues.md
+++ b/docs/common_issues.md
@@ -198,3 +198,21 @@ is defined by the schema. If not, remove from example or correct
 spelling mistake. Rebuild and check will pass again.
 
 </details>
+
+
+## Other issues
+
+<details>
+<summary>check: "unexpected end of the stream within a flow collection"</summary>
+
+### Restore the json file being referenced
+
+The probable cause is a current.json file has a $ref and the
+current.json or released files for that $ref has
+been left as invalid JSON. For example, it was edited my
+mistake whilst reviewing the properties being reused.
+
+**Fix:** Find the $id being referenced and restoring the required
+file or use IDE undo buffer.
+
+</details>

--- a/docs/common_issues.md
+++ b/docs/common_issues.md
@@ -14,9 +14,10 @@ When fixing errors in general you will need to:
 
 2. Target the build: `npm run build-new path-to-current-dot-json`
    or `npm run build-modified` if changes were made to a
-   committed files. The `npm run build-all` command can
-   make it more difficult to track down some issues
-   and fix them.
+   committed files or `npm run build-main-diff` to build
+   current.json files different than origin/main branch.
+   The `npm run build-all` command can make it more difficult
+   to track down some issues and fix them.
 
 3. Do check via: `npm run check` 
 
@@ -106,5 +107,68 @@ important and so are each version. A schema folder
 moving in the schema root requires every $ref in
 every version to be updated to the new
 path. Build order is important for schema.
+
+</details>
+
+## Schema changed and $id number was not updated correctly
+
+All changes to a schema should start with the $id
+being edited in current.json to make at least
+a point release. It helps ensure all schema files do
+not change in uncontrolled ways which applications
+cannot be expected to detect or support. Changing
+the $id is not enforced, except in certain
+cases like these. If you see any of the following it means
+semantic version number in $id was wrong in some way.
+
+<details>
+<summary>check: "Requiredness of properties cannot be modified at: .required"</summary>
+
+### Major release is needed
+
+This occurs whenever a property become required and there has
+been least one previous release. The property may have
+been optional in an earlier release. 
+
+If the $id being fixed has been used as a $ref you should raise
+a Github issue labelled "major" that is mentioned on a PR. To
+find these do a search for the $id without semantic version and
+look for $ref lines. Add the $id of any current.json file found
+to the issue. Writers of those schema can decided when to do
+major release after your major release is merged to main.
+
+The fix below uses a pretend schema that had
+release 1.1.6 merged to main. Months later an attempt
+to make a property required caused this issue.
+
+1. Edit the $id value so the major version is increased
+   by one. Reset minor and point numbers to 0. So, an $id
+   ending with 1.1.7 would become 2.0.0 to fix the issue.
+
+2. The next build will create new files and update the
+   latest links. Two tips: do cleanup before push to
+   github; start a new branch if cleanup 3 is needed and
+   follow the recommendation.
+
+#### Cleanup is required before check will pass
+
+The first cleanup assumes a point release in $id was the
+first value altered before other changes. Cleanup 2 and 3
+are required when that recommendation was not applied.
+
+   * **Cleanup 1 (best case)** - Files built or committed with
+that release need deleting from branch. In example, files 1.1.7
+and 1.1.7.json were built and need deleting.
+
+   * **Cleanup 2 (okay case)** The files (already merged to
+main) **must** be restored to the branch. In example, changes
+to files 1.1.6 and 1.1.6.json need undoing.
+
+   * **Cleanup 3 (worse case)** when the $id being fixed has
+been used as a $ref and `build-new` command was not used. A
+git diff or commit log will show pairs of files that
+need restoring from main. Since
+each schema is seperate they will have different
+release numbers. Often quicker to start new branch.
 
 </details>


### PR DESCRIPTION
This PR contains three issues and fixes seen whilst testing schema tools.

The first (major release) is the most important. Avoiding cleanup 2 and 3 is one reason for the recommendation to always edit the point release in the $id before making other changes to a schema.

If we only use automatic examples issue 2 is unlikely. But, adding examples manually is likely to make schema and applications more robust. Using the examples in a release is recommend when testing applications using that release. So, example 0 has required properties only. Example 1 adds properties most likely to be used by applications. Example 2..N contain variations or edge cases known to be used by applications. 

The third issue about stream flow is mostly like when doing local builds of a schema using a $ref and that $ref file exists but is invalid for whatever reason.